### PR TITLE
Changed call to unicode() to work with Python 3.

### DIFF
--- a/snakes/plugins/gv.py
+++ b/snakes/plugins/gv.py
@@ -56,6 +56,14 @@ import os, os.path, subprocess, collections, codecs
 import snakes.plugins
 from snakes.plugins.clusters import Cluster
 from snakes.compat import *
+import sys
+
+# unicode() is no longer supported in Python 3, in which
+# a call to str() now does the job.
+if sys.version_info[0] < 3:
+    unicode_or_str = unicode
+else:
+    unicode_or_str = str
 
 # apidoc skip
 class Graph (Cluster) :
@@ -83,7 +91,7 @@ class Graph (Cluster) :
         else :
             tag = "%s " % tag
         return (["%s[" % tag,
-                 ["%s=%s" % (key, self.escape(unicode(val)))
+                 ["%s=%s" % (key, self.escape(unicode_or_str(val)))
                   for key, val in attr.items()],
                  "];"])
     def _dot (self) :
@@ -102,7 +110,7 @@ class Graph (Cluster) :
         return lines
     def _dot_text (self, lines, indent=0) :
         for l in lines :
-            if isinstance(l, (str, unicode)) :
+            if isinstance(l, (str, unicode_or_str)) :
                 yield " "*indent*2 + l
             else :
                 for x in self._dot_text(l, indent+1) :


### PR DESCRIPTION
Python 3 no longer supports the unicode() function. I got this error when I tried the gv plugin:

    NameError: name 'unicode' is not defined

It seems that str() now does the job, so I selectively (i.e., when Python version is >= 3) changed calls to unicode() to str(). After I made the change, it worked with Python 3, I got my drawings. However, I have not tested it in Python 2 (but it should work).

More details about the unicode() function here: https://stackoverflow.com/questions/36110598/nameerror-name-unicode-is-not-defined